### PR TITLE
Dockerfile: add riscv64 with QemuBuild.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ ia32/code.fd
 aarch64/vars.fd
 aarch64/code.fd
 aarch64/shell.efi
+riscv64/vars.fd
+riscv64/code.fd
+riscv64/shell.efi
 ```
 
 [**Latest Release**](https://github.com/rust-osdev/ovmf-prebuilt/releases/latest)


### PR DESCRIPTION
With the latest stable release of EDK2 (edk2-stable202308) i was able to start the efi shell on qemu-system-riscv64.

Adds the code/vars/shell for riscv64 system

Tested with QEMU 8.1.0