### PR TITLE
Fix "unknown feature" error on compile attempt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,13 +197,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "proc-macro2",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.71"
 clap = { version = "4.2.7", features = ["derive"] }
+proc-macro2 = "^1.0.59"


### PR DESCRIPTION
Versions of the `proc_macro2` dependency (which is a dependency of a dependency of this) prior to 1.59 use a Rust feature flag that no longer exists, resulting in a compilation error. Depending on a newer version of `proc_macro2` solves this problem.