### PR TITLE
renovate: Change stategy to update-lockfile

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,7 @@
       "on wednesday"
     ]
   },
-  "rangeStrategy": "replace",
+  "rangeStrategy": "update-lockfile",
   "schedule": [
     "on wednesday"
   ]


### PR DESCRIPTION
Support for this strategy was added recently:
https://github.com/renovatebot/renovate/issues/22820. It seems that at the same time the behavior of the "replace" strategy changed, causing PRs to be opened with unnecessary changes to Cargo.toml.