### PR TITLE
release: 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "ovmf-prebuilt"
-version = "0.3.0"
+version = "0.2.0"
 dependencies = [
  "log",
  "lzma-rs",

--- a/ovmf-prebuilt/Cargo.toml
+++ b/ovmf-prebuilt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ovmf-prebuilt"
-version = "0.3.0"
+version = "0.2.0"
 edition.workspace = true
 categories = ["development-tools"]
 keywords = ["edk2", "firmware", "ovmf", "prebuilt"]


### PR DESCRIPTION
Move the version down from 0.3.0; I bumped it to 0.3 in https://github.com/rust-osdev/ovmf-prebuilt/pull/93 but forgot that we never did a 0.2 release, so no need to skip that version number.