### PR TITLE
release: 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,7 +498,7 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "ovmf-prebuilt"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "log",
  "lzma-rs",

--- a/ovmf-prebuilt/Cargo.toml
+++ b/ovmf-prebuilt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ovmf-prebuilt"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 categories = ["development-tools"]
 keywords = ["edk2", "firmware", "ovmf", "prebuilt"]


### PR DESCRIPTION
This release just updates the readme so that it no longer says the library "is not yet implemented" on crates.io.