### PR TITLE
Set `Source::LATEST` to `EDK2_STABLE202502_R1`

### DIFF
--- a/ovmf-prebuilt/src/lib.rs
+++ b/ovmf-prebuilt/src/lib.rs
@@ -62,7 +62,7 @@ impl Source {
     ///
     /// Note that this is not necessarily the latest prebuilt available
     /// from the git repo.
-    pub const LATEST: Self = Self::EDK2_STABLE202408_R1;
+    pub const LATEST: Self = Self::EDK2_STABLE202502_R1;
 }
 
 /// UEFI architecture.


### PR DESCRIPTION
The new tags have been added in https://github.com/rust-osdev/ovmf-prebuilt/pull/139, but `Source::LATEST` had not been updated.