### PR TITLE
build-edk2: Enable NETWORK_TLS build option

### DIFF
--- a/build-edk2/Dockerfile
+++ b/build-edk2/Dockerfile
@@ -31,7 +31,7 @@ ENV toolchain=GCC5
 RUN . venv/bin/activate && python BaseTools/Edk2ToolsBuild.py -t "${toolchain}"
 
 # Build options.
-ENV common_build_opt="BLD_*_NETWORK_HTTP_ENABLE=1"
+ENV common_build_opt="BLD_*_NETWORK_HTTP_ENABLE=1 BLD_*_NETWORK_TLS_ENABLE=1"
 ENV tpm_build_opt="BLD_*_TPM1_ENABLE=1 BLD_*_TPM2_ENABLE=1"
 
 # Build AARCH64.

--- a/build-edk2/Dockerfile
+++ b/build-edk2/Dockerfile
@@ -30,24 +30,28 @@ RUN . venv/bin/activate && pip install -r pip-requirements.txt --upgrade
 ENV toolchain=GCC5
 RUN . venv/bin/activate && python BaseTools/Edk2ToolsBuild.py -t "${toolchain}"
 
+# Build options.
+ENV common_build_opt="BLD_*_NETWORK_HTTP_ENABLE=1"
+ENV tpm_build_opt="BLD_*_TPM1_ENABLE=1 BLD_*_TPM2_ENABLE=1"
+
 # Build AARCH64.
 ENV GCC5_AARCH64_PREFIX="/usr/bin/aarch64-linux-gnu-"
 ENV build_target=RELEASE
-ENV stuart_opts="-c ArmVirtPkg/PlatformCI/QemuBuild.py -a AARCH64 Target=${build_target} TOOL_CHAIN_TAG=${toolchain} BLD_*_NETWORK_HTTP_ENABLE=1"
+ENV stuart_opts="-c ArmVirtPkg/PlatformCI/QemuBuild.py -a AARCH64 Target=${build_target} TOOL_CHAIN_TAG=${toolchain} ${common_build_opt}"
 RUN . venv/bin/activate && stuart_setup ${stuart_opts} && stuart_update ${stuart_opts} && stuart_build ${stuart_opts}
 
 # Build RiscV.
 ENV GCC5_RISCV64_PREFIX="/opt/riscv/bin/riscv64-unknown-elf-"
 ENV build_target=RELEASE
-ENV stuart_opts="-c OvmfPkg/PlatformCI/QemuBuild.py -a RISCV64 Target=${build_target} TOOL_CHAIN_TAG=${toolchain} BLD_*_NETWORK_HTTP_ENABLE=1"
+ENV stuart_opts="-c OvmfPkg/PlatformCI/QemuBuild.py -a RISCV64 Target=${build_target} TOOL_CHAIN_TAG=${toolchain} ${common_build_opt}"
 RUN . venv/bin/activate && stuart_setup ${stuart_opts} && stuart_update ${stuart_opts} && stuart_build ${stuart_opts}
 
 # Build IA32.
-ENV stuart_opts="-c OvmfPkg/PlatformCI/PlatformBuild.py -a IA32 Target=${build_target} TOOL_CHAIN_TAG=${toolchain} BLD_*_NETWORK_HTTP_ENABLE=1 BLD_*_TPM1_ENABLE=1 BLD_*_TPM2_ENABLE=1"
+ENV stuart_opts="-c OvmfPkg/PlatformCI/PlatformBuild.py -a IA32 Target=${build_target} TOOL_CHAIN_TAG=${toolchain} ${common_build_opt} ${tpm_build_opt}"
 RUN . venv/bin/activate && stuart_setup ${stuart_opts} && stuart_update ${stuart_opts} && stuart_build ${stuart_opts}
 
 # Build X64.
-ENV stuart_opts="-c OvmfPkg/PlatformCI/PlatformBuild.py -a X64 Target=${build_target} TOOL_CHAIN_TAG=${toolchain} BLD_*_NETWORK_HTTP_ENABLE=1 BLD_*_TPM1_ENABLE=1 BLD_*_TPM2_ENABLE=1"
+ENV stuart_opts="-c OvmfPkg/PlatformCI/PlatformBuild.py -a X64 Target=${build_target} TOOL_CHAIN_TAG=${toolchain} ${common_build_opt} ${tpm_build_opt}"
 RUN . venv/bin/activate && stuart_setup ${stuart_opts} && stuart_update ${stuart_opts} && stuart_build ${stuart_opts}
 
 # Create the output bin dir.


### PR DESCRIPTION
The first commit deduplicates the various build options in the dockerfile to make it easier to add new build options.

The second commit enables NETWORK_TLS, as suggested here: https://github.com/rust-osdev/uefi-rs/pull/1614#issuecomment-2809546867