### PR TITLE
Split Source constants into a new file

### DIFF
--- a/ovmf-prebuilt/src/lib.rs
+++ b/ovmf-prebuilt/src/lib.rs
@@ -20,6 +20,7 @@
 
 mod error;
 mod fetch;
+mod source_constants;
 
 use fetch::update_cache;
 use std::path::{Path, PathBuf};
@@ -34,40 +35,6 @@ pub struct Source {
 
     /// SHA-256 hash of the compressed tarball.
     pub sha256: &'static str,
-}
-
-#[allow(missing_docs)]
-impl Source {
-    pub const EDK2_STABLE202408_R1: Self = Self {
-        tag: "edk2-stable202408-r1",
-        sha256: "63a9217ddd51fa45d0a89fd83c483cc971765de6bb08e83cf70836b0baff0d48",
-    };
-
-    pub const EDK2_STABLE202408_01_R1: Self = Self {
-        tag: "edk2-stable202408.01-r1",
-        sha256: "1b4c7d7603517482a3c4461ba43044c4c7e0a7930274d77eb19600b7dcd9b838",
-    };
-
-    pub const EDK2_STABLE202411_R1: Self = Self {
-        tag: "edk2-stable202411-r1",
-        sha256: "963fc6cef6a0560cec97381ed22a7d5c76f440c8212529a034cb465466cd57cc",
-    };
-
-    pub const EDK2_STABLE202502_R1: Self = Self {
-        tag: "edk2-stable202502-r1",
-        sha256: "6d6122e88cdc09e1ffafb6a39fbdbfba668a6ded3f2a032b2cd6c0b7ff6d69df",
-    };
-
-    pub const EDK2_STABLE202502_R2: Self = Self {
-        tag: "edk2-stable202502-r2",
-        sha256: "dd59d3d52f0a643f07a488f80ab40f89c30f360999d98cdffb30e1eba5476641",
-    };
-
-    /// Latest release tag.
-    ///
-    /// Note that this is not necessarily the latest prebuilt available
-    /// from the git repo.
-    pub const LATEST: Self = Self::EDK2_STABLE202502_R2;
 }
 
 /// UEFI architecture.

--- a/ovmf-prebuilt/src/source_constants.rs
+++ b/ovmf-prebuilt/src/source_constants.rs
@@ -1,0 +1,35 @@
+use crate::Source;
+
+#[allow(missing_docs)]
+impl Source {
+    pub const EDK2_STABLE202408_R1: Self = Self {
+        tag: "edk2-stable202408-r1",
+        sha256: "63a9217ddd51fa45d0a89fd83c483cc971765de6bb08e83cf70836b0baff0d48",
+    };
+
+    pub const EDK2_STABLE202408_01_R1: Self = Self {
+        tag: "edk2-stable202408.01-r1",
+        sha256: "1b4c7d7603517482a3c4461ba43044c4c7e0a7930274d77eb19600b7dcd9b838",
+    };
+
+    pub const EDK2_STABLE202411_R1: Self = Self {
+        tag: "edk2-stable202411-r1",
+        sha256: "963fc6cef6a0560cec97381ed22a7d5c76f440c8212529a034cb465466cd57cc",
+    };
+
+    pub const EDK2_STABLE202502_R1: Self = Self {
+        tag: "edk2-stable202502-r1",
+        sha256: "6d6122e88cdc09e1ffafb6a39fbdbfba668a6ded3f2a032b2cd6c0b7ff6d69df",
+    };
+
+    pub const EDK2_STABLE202502_R2: Self = Self {
+        tag: "edk2-stable202502-r2",
+        sha256: "dd59d3d52f0a643f07a488f80ab40f89c30f360999d98cdffb30e1eba5476641",
+    };
+
+    /// Latest release tag.
+    ///
+    /// Note that this is not necessarily the latest prebuilt available
+    /// from the git repo.
+    pub const LATEST: Self = Self::EDK2_STABLE202502_R2;
+}


### PR DESCRIPTION
This will make it slightly easier to generate automatic updates to the Source list when a new prebuilt is released, since the whole `source_constants.rs` file can be generated, rather than modifying a section of `lib.rs` in-place.